### PR TITLE
docs(cli): include generate help

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,4 +144,28 @@ Commands:
   generate [options]  Generate node identities, configure consensus, and emit a
                       Besu genesis.
   help [command]      display help for command
+
+
+Usage: network-bootstrapper generate [options]
+
+Generate node identities, configure consensus, and emit a Besu genesis.
+
+Options:
+  -v, --validators <count>               Number of validator nodes to generate. (default: 4)
+  -a, --allocations <file>               Path to a genesis allocations JSON file. (default: none)
+  -o, --outputType <type>                Output target (screen, file, kubernetes). (default: "screen")
+  --static-node-domain <domain>          DNS suffix appended to validator peer hostnames for static-nodes entries.
+  --static-node-namespace <name>         Namespace segment inserted between service name and domain for static-nodes entries.
+  --static-node-port <number>            P2P port used for static-nodes enode URIs. (default: 30303)
+  --static-node-discovery-port <number>  Discovery port used for static-nodes enode URIs. (default: 30303)
+  --consensus <algorithm>                Consensus algorithm (IBFTv2, QBFT). (default: QBFT)
+  --chain-id <number>                    Chain ID for the genesis config. (default: random between 40000 and 50000)
+  --seconds-per-block <number>           Block time in seconds. (default: 2)
+  --gas-limit <decimal>                  Block gas limit in decimal form. (default: 9007199254740991)
+  --gas-price <number>                   Base gas price (wei). (default: 0)
+  --evm-stack-size <number>              EVM stack size limit. (default: 2048)
+  --contract-size-limit <number>         Contract size limit in bytes. (default: 2147483647)
+  --accept-defaults                      Accept default values for all prompts when CLI flags are omitted. (default: disabled)
+  -h, --help                             display help for command
+
 ```

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "bun test",
     "helm": "helm upgrade --install network ./charts/network -n network --create-namespace --timeout 15m",
     "docs:helm": "helm-docs --chart-search-root=. --skip-version-footer",
-    "docs:cli": "cat README.tpl > README.md && echo '\n```' >> README.md && bun src/index.ts --help >> README.md && echo '```' >> README.md",
+    "docs:cli": "cat README.tpl > README.md && printf '\\n```\\n' >> README.md && bun src/index.ts --help >> README.md && printf '\\n\\n' >> README.md && bun src/index.ts generate --help >> README.md && printf '\\n```\\n' >> README.md",
     "package:pack": "helm package charts/network --destination .",
     "package:push:harbor": "helm push ./network-*.tgz oci://harbor.settlemint.com/atk"
   },


### PR DESCRIPTION
## Summary by Sourcery

Include the `generate` command help in the README and update the docs generation script to append its output.

Build:
- Extend the `docs:cli` npm script to run `bun src/index.ts generate --help` and include its output in the generated README

Documentation:
- Add `Usage` and `Options` sections for the `network-bootstrapper generate` command to the CLI documentation in README.md