### PR TITLE
chore(ci): publish helm charts to gh-pages on tags

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -58,8 +58,6 @@ jobs:
         env:
           SLACK_BOT_TOKEN: op://platform/slack-bot/SLACK_BOT_TOKEN
           SLACK_CHANNEL_ID: op://platform/slack-bot/SLACK_CHANNEL_ID
-          HARBOR_USER: op://platform/harbor/username
-          HARBOR_PASS: op://platform/harbor/password
           PAT_TOKEN: op://platform/github-commit-pat/credential
 
       # Label QA as running and notify Slack (only for non-draft PRs)
@@ -272,27 +270,14 @@ jobs:
             ${{ steps.secret-scan.outcome == 'success' && 'success' || 'failure'
             }}
 
-      - name: Login to Harbor
+      - name: Publish Helm charts to GitHub Pages
         if: |
-          github.event_name == 'push' ||
-          (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3
+          github.event_name == 'push' &&
+          startsWith(github.ref, 'refs/tags/')
+        uses: stefanprodan/helm-gh-pages@v1.7.0
         with:
-          registry: harbor.settlemint.com
-          username: ${{ env.HARBOR_USER }}
-          password: ${{ env.HARBOR_PASS }}
-
-      - name: Package chart
-        if: |
-          github.event_name == 'push' ||
-          (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
-        run: bun run package:pack
-
-      - name: Push chart to Harbor
-        if: |
-          github.event_name == 'push' ||
-          (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
-        run: bun run package:push:harbor
+          token: ${{ secrets.GITHUB_TOKEN }}
+          charts_dir: charts
 
       # Check PR review status (PR and PR review events only)
       - name: Check PR review status

--- a/package.json
+++ b/package.json
@@ -26,9 +26,7 @@
     "test": "bun test",
     "helm": "helm upgrade --install network ./charts/network -n network --create-namespace --timeout 15m",
     "docs:helm": "helm-docs --chart-search-root=. --skip-version-footer",
-    "docs:cli": "cat README.tpl > README.md && printf '\\n```\\n' >> README.md && bun src/index.ts --help >> README.md && printf '\\n\\n' >> README.md && bun src/index.ts generate --help >> README.md && printf '\\n```\\n' >> README.md",
-    "package:pack": "helm package charts/network --destination .",
-    "package:push:harbor": "helm push ./network-*.tgz oci://harbor.settlemint.com/atk"
+    "docs:cli": "cat README.tpl > README.md && printf '\\n```\\n' >> README.md && bun src/index.ts --help >> README.md && printf '\\n\\n' >> README.md && bun src/index.ts generate --help >> README.md && printf '\\n```\\n' >> README.md"
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.4",


### PR DESCRIPTION
## Summary
- replace Harbor registry push with helm-gh-pages publishing
- restrict chart publishing to tagged pushes
- remove the unused Helm packaging script

## Testing
- bun check
- bun test
- bun typecheck

## Summary by Sourcery

Switch Helm chart publishing in the CI workflow from Harbor to GitHub Pages on tagged releases and remove associated packaging scripts.

CI:
- Remove Harbor login and chart push steps from the QA workflow
- Add helm-gh-pages action to publish charts on push events to Git tags
- Limit chart publishing step to tag references only

Chores:
- Remove unused Helm packaging and Harbor push scripts from package.json
- Clean up Harbor credentials from CI environment variables