### PR TITLE
feat: parallel deployment and better readiness check

### DIFF
--- a/charts/network/charts/network-nodes/README.md
+++ b/charts/network/charts/network-nodes/README.md
@@ -82,7 +82,7 @@ A Helm chart for Kubernetes
 | initContainers.shared | list|string | `[]` | Init containers applied to both validator and RPC pods. |
 | initContainers.validator | list|string | `[]` | Additional init containers exclusively for validator pods. |
 | livenessProbe.failureThreshold | int | `3` | Consecutive failures required before the container is restarted. |
-| livenessProbe.httpGet.path | string | `"/liveness"` | HTTP path used for liveness probing. |
+| livenessProbe.httpGet.path | string | `"/readiness?minPeers=1&maxBlocksBehind=100"` | HTTP path used for liveness probing. |
 | livenessProbe.httpGet.port | string|int | `"json-rpc"` | Target container port serving the liveness endpoint. |
 | livenessProbe.initialDelaySeconds | int | `30` | Seconds to wait before starting liveness checks. |
 | livenessProbe.periodSeconds | int | `10` | Frequency of liveness checks in seconds. |
@@ -119,7 +119,7 @@ A Helm chart for Kubernetes
 | podLabels | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | readinessProbe.failureThreshold | int | `3` | Consecutive failures required before the pod is considered unready. |
-| readinessProbe.httpGet.path | string | `"/readiness?minPeers=1&maxBlocksBehind=100"` | HTTP path used for readiness probing, including peer/sync thresholds. |
+| readinessProbe.httpGet.path | string | `"/readiness?minPeers=0&maxBlocksBehind=100"` | HTTP path used for readiness probing, including peer/sync thresholds. |
 | readinessProbe.httpGet.port | string|int | `"json-rpc"` | Target container port serving the readiness endpoint. |
 | readinessProbe.initialDelaySeconds | int | `15` | Seconds to wait before starting readiness checks. |
 | readinessProbe.periodSeconds | int | `5` | Frequency of readiness checks in seconds. |

--- a/charts/network/charts/network-nodes/README.md
+++ b/charts/network/charts/network-nodes/README.md
@@ -119,10 +119,10 @@ A Helm chart for Kubernetes
 | podLabels | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | readinessProbe.failureThreshold | int | `3` | Consecutive failures required before the pod is considered unready. |
-| readinessProbe.httpGet.path | string | `"/readiness?minPeers=0&maxBlocksBehind=100"` | HTTP path used for readiness probing, including peer/sync thresholds. |
+| readinessProbe.httpGet.path | string | `"/readiness?minPeers=1&maxBlocksBehind=100"` | HTTP path used for readiness probing, including peer/sync thresholds. |
 | readinessProbe.httpGet.port | string|int | `"json-rpc"` | Target container port serving the readiness endpoint. |
 | readinessProbe.initialDelaySeconds | int | `15` | Seconds to wait before starting readiness checks. |
-| readinessProbe.periodSeconds | int | `10` | Frequency of readiness checks in seconds. |
+| readinessProbe.periodSeconds | int | `5` | Frequency of readiness checks in seconds. |
 | readinessProbe.timeoutSeconds | int | `2` | Timeout in seconds before marking the probe as failed. |
 | resources | object | `{}` |  |
 | rpcReplicaCount | int | `2` | Number of RPC node replicas provisioned via StatefulSet. |

--- a/charts/network/charts/network-nodes/templates/statefulset-validator.yaml
+++ b/charts/network/charts/network-nodes/templates/statefulset-validator.yaml
@@ -35,6 +35,7 @@ spec:
   {{- $initContainers := .Values.initContainers | default (dict) }}
   {{- $sharedInitContainers := get $initContainers "shared" }}
   {{- $validatorInitContainers := get $initContainers "validator" }}
+  podManagementPolicy: Parallel
   replicas: {{ $validatorReplicaBudget }}
   serviceName: {{ include "nodes.fullname" . }}
   {{- if and $useClaimTemplate (or (ne $whenDeleted "") (ne $whenScaled "")) }}

--- a/charts/network/charts/network-nodes/values.yaml
+++ b/charts/network/charts/network-nodes/values.yaml
@@ -334,7 +334,7 @@ livenessProbe:
   # HTTP GET probe configuration hitting the Besu liveness endpoint.
   httpGet:
     # -- (string) HTTP path used for liveness probing.
-    path: /liveness
+    path: /readiness?minPeers=1&maxBlocksBehind=100
     # -- (string|int) Target container port serving the liveness endpoint.
     port: json-rpc
   # -- (int) Seconds to wait before starting liveness checks.
@@ -351,7 +351,7 @@ readinessProbe:
   # HTTP GET probe configuration hitting the Besu readiness endpoint.
   httpGet:
     # -- (string) HTTP path used for readiness probing, including peer/sync thresholds.
-    path: /readiness?minPeers=1&maxBlocksBehind=100
+    path: /readiness?minPeers=0&maxBlocksBehind=100
     # -- (string|int) Target container port serving the readiness endpoint.
     port: json-rpc
   # -- (int) Seconds to wait before starting readiness checks.

--- a/charts/network/charts/network-nodes/values.yaml
+++ b/charts/network/charts/network-nodes/values.yaml
@@ -351,13 +351,13 @@ readinessProbe:
   # HTTP GET probe configuration hitting the Besu readiness endpoint.
   httpGet:
     # -- (string) HTTP path used for readiness probing, including peer/sync thresholds.
-    path: /readiness?minPeers=0&maxBlocksBehind=100
+    path: /readiness?minPeers=1&maxBlocksBehind=100
     # -- (string|int) Target container port serving the readiness endpoint.
     port: json-rpc
   # -- (int) Seconds to wait before starting readiness checks.
   initialDelaySeconds: 15
   # -- (int) Frequency of readiness checks in seconds.
-  periodSeconds: 10
+  periodSeconds: 5
   # -- (int) Timeout in seconds before marking the probe as failed.
   timeoutSeconds: 2
   # -- (int) Consecutive failures required before the pod is considered unready.


### PR DESCRIPTION
## Summary by Sourcery

Enable parallel rolling updates of validator StatefulSets and tighten readiness checks by updating probe thresholds and frequency

New Features:
- Enable parallel deployment of validator pods by setting podManagementPolicy to Parallel

Enhancements:
- Adjust readiness probe to require at least one peer and reduce probe period to 5 seconds