### PR TITLE
fix: keep global security defaults scoped

### DIFF
--- a/charts/network/charts/network-bootstrapper/templates/_helpers.tpl
+++ b/charts/network/charts/network-bootstrapper/templates/_helpers.tpl
@@ -82,10 +82,12 @@ Accepts either a YAML string or a list of init container maps and indents output
 Resolve pod and container security contexts by layering chart values over global defaults.
 */}}
 {{- define "network-bootstrapper.securityContexts" -}}
-{{- $root := . -}}
-{{- $globalValues := ($root.Values.global | default (dict)) -}}
-{{- $globalSecurityContexts := dig "securityContexts" $globalValues (dict) -}}
-{{- $pod := mergeOverwrite (deepCopy (dig "pod" $globalSecurityContexts (dict))) (default (dict) $root.Values.podSecurityContext) -}}
-{{- $container := mergeOverwrite (deepCopy (dig "container" $globalSecurityContexts (dict))) (default (dict) $root.Values.securityContext) -}}
-{{- dict "pod" $pod "container" $container | toYaml -}}
+{{- $ctx := index . "ctx" -}}
+{{- $dest := index . "dest" -}}
+{{- $globalValues := ($ctx.Values.global | default (dict)) -}}
+{{- $globalSecurityContexts := default (dict) (get $globalValues "securityContexts") -}}
+{{- $podDefaults := default (dict) (get $globalSecurityContexts "pod") -}}
+{{- $containerDefaults := default (dict) (get $globalSecurityContexts "container") -}}
+{{- $_ := set $dest "pod" (mergeOverwrite (deepCopy $podDefaults) (default (dict) $ctx.Values.podSecurityContext)) -}}
+{{- $_ := set $dest "container" (mergeOverwrite (deepCopy $containerDefaults) (default (dict) $ctx.Values.securityContext)) -}}
 {{- end -}}

--- a/charts/network/charts/network-bootstrapper/templates/job.yaml
+++ b/charts/network/charts/network-bootstrapper/templates/job.yaml
@@ -27,7 +27,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "network-bootstrapper.serviceAccountName" . }}
-      {{- $securityContexts := include "network-bootstrapper.securityContexts" . | fromYaml }}
+      {{- $securityContexts := dict -}}
+      {{- include "network-bootstrapper.securityContexts" (dict "ctx" . "dest" $securityContexts) -}}
       {{- $podSecurityContext := index $securityContexts "pod" }}
       {{- $containerSecurityContext := index $securityContexts "container" }}
       {{- if $podSecurityContext }}

--- a/charts/network/charts/network-nodes/templates/_helpers.tpl
+++ b/charts/network/charts/network-nodes/templates/_helpers.tpl
@@ -131,10 +131,12 @@ Accepts either a YAML string or a list of init container maps and indents output
 Resolve pod and container security contexts using global defaults plus chart overrides.
 */}}
 {{- define "nodes.securityContexts" -}}
-{{- $root := . -}}
-{{- $globalValues := ($root.Values.global | default (dict)) -}}
-{{- $globalSecurityContexts := dig "securityContexts" $globalValues (dict) -}}
-{{- $pod := mergeOverwrite (deepCopy (dig "pod" $globalSecurityContexts (dict))) (default (dict) $root.Values.podSecurityContext) -}}
-{{- $container := mergeOverwrite (deepCopy (dig "container" $globalSecurityContexts (dict))) (default (dict) $root.Values.securityContext) -}}
-{{- dict "pod" $pod "container" $container | toYaml -}}
+{{- $ctx := index . "ctx" -}}
+{{- $dest := index . "dest" -}}
+{{- $globalValues := ($ctx.Values.global | default (dict)) -}}
+{{- $globalSecurityContexts := default (dict) (get $globalValues "securityContexts") -}}
+{{- $podDefaults := default (dict) (get $globalSecurityContexts "pod") -}}
+{{- $containerDefaults := default (dict) (get $globalSecurityContexts "container") -}}
+{{- $_ := set $dest "pod" (mergeOverwrite (deepCopy $podDefaults) (default (dict) $ctx.Values.podSecurityContext)) -}}
+{{- $_ := set $dest "container" (mergeOverwrite (deepCopy $containerDefaults) (default (dict) $ctx.Values.securityContext)) -}}
 {{- end -}}

--- a/charts/network/charts/network-nodes/templates/statefulset-rpc.yaml
+++ b/charts/network/charts/network-nodes/templates/statefulset-rpc.yaml
@@ -36,7 +36,8 @@ spec:
   {{- $initContainers := .Values.initContainers | default (dict) }}
   {{- $sharedInitContainers := get $initContainers "shared" }}
   {{- $rpcInitContainers := get $initContainers "rpc" }}
-  {{- $securityContexts := include "nodes.securityContexts" . | fromYaml }}
+  {{- $securityContexts := dict -}}
+  {{- include "nodes.securityContexts" (dict "ctx" . "dest" $securityContexts) -}}
   {{- $podSecurityContext := index $securityContexts "pod" }}
   {{- $containerSecurityContext := index $securityContexts "container" }}
   podManagementPolicy: Parallel

--- a/charts/network/charts/network-nodes/templates/statefulset-validator.yaml
+++ b/charts/network/charts/network-nodes/templates/statefulset-validator.yaml
@@ -37,7 +37,8 @@ spec:
   {{- $initContainers := .Values.initContainers | default (dict) }}
   {{- $sharedInitContainers := get $initContainers "shared" }}
   {{- $validatorInitContainers := get $initContainers "validator" }}
-  {{- $securityContexts := include "nodes.securityContexts" . | fromYaml }}
+  {{- $securityContexts := dict -}}
+  {{- include "nodes.securityContexts" (dict "ctx" . "dest" $securityContexts) -}}
   {{- $podSecurityContext := index $securityContexts "pod" }}
   {{- $containerSecurityContext := index $securityContexts "container" }}
   podManagementPolicy: Parallel


### PR DESCRIPTION
## Summary
- resolve global security context defaults into a temporary map instead of emitting raw YAML
- merge pod/container contexts with set-based helper to avoid leaking other global values into securityContext blocks
- update Besu and bootstrapper manifests to consume the shared helper without fromYaml conversions

## Testing
- helm template test charts/network --namespace test
- bun run check
- bun run typecheck
- bun run test

## Summary by Sourcery

Refactor Helm chart security context helpers to isolate global defaults in a scoped map and update chart templates to use the new helper signature, eliminating raw YAML emission and parsing.

Bug Fixes:
- Prevent leaking unrelated global securityContext values into pod and container contexts

Enhancements:
- Refactor securityContexts helper to accept a destination map and merge global pod/container defaults with chart overrides in-place
- Update network-bootstrapper and network-nodes templates to initialize a dest dict and invoke the refactored helper without relying on raw YAML or fromYaml parsing