### PR TITLE
feat: publish subgraph hash configmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Options:
   -v, --validators <count>               Number of validator nodes to generate. (default: 4)
   -a, --allocations <file>               Path to a genesis allocations JSON file. (default: none)
   --abi-directory <path>                 Directory containing ABI JSON files to publish as ConfigMaps.
+  --subgraph-hash-file <path>            Path to a file containing the subgraph IPFS hash.
   -o, --outputType <type>                Output target (screen, file, kubernetes). (default: "screen")
   --static-node-port <number>            P2P port used for static-nodes enode URIs. (default: 30303)
   --static-node-discovery-port <number>  Discovery port used for static-nodes enode URIs. (default: 30303)

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@kubernetes/client-node": "1.3.0",
         "commander": "14.0.1",
         "lefthook": "1.13.1",
+        "multiformats": "12.1.3",
         "ox": "0.9.6",
         "viem": "2.37.7",
         "yaml": "2.8.1",
@@ -401,6 +402,8 @@
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "multiformats": ["multiformats@12.1.3", "", {}, "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw=="],
 
     "mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@inquirer/prompts": "7.8.6",
     "@kubernetes/client-node": "1.3.0",
     "commander": "14.0.1",
+    "multiformats": "12.1.3",
     "lefthook": "1.13.1",
     "ox": "0.9.6",
     "viem": "2.37.7",

--- a/src/cli/commands/bootstrap/bootstrap.subgraph.test.ts
+++ b/src/cli/commands/bootstrap/bootstrap.subgraph.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+
+import { loadSubgraphHash } from "./bootstrap.subgraph.ts";
+
+const TMP_DIR = join(process.cwd(), "tmp-subgraph-tests");
+const writeTempFile = async (
+  name: string,
+  contents: string
+): Promise<string> => {
+  await mkdir(TMP_DIR, { recursive: true });
+  const path = join(TMP_DIR, name);
+  await Bun.write(path, contents);
+  return path;
+};
+
+afterEach(async () => {
+  await rm(TMP_DIR, { recursive: true, force: true });
+});
+
+describe("loadSubgraphHash", () => {
+  test("reads and validates CID values", async () => {
+    const cid = "bafybeigdyrztzd4gufq2bdsd6we3jh7uzulnd2ipkyli5sto6f5j6rlude";
+    const path = await writeTempFile("hash.txt", `${cid}\n`);
+
+    const loaded = await loadSubgraphHash(path);
+
+    expect(loaded).toBe(cid);
+  });
+
+  test("throws when file does not exist", async () => {
+    await expect(
+      loadSubgraphHash(join(TMP_DIR, "missing.txt"))
+    ).rejects.toThrow("Subgraph hash file not found");
+  });
+
+  test("throws when file is empty", async () => {
+    const path = await writeTempFile("empty.txt", "   \n\t  ");
+
+    await expect(loadSubgraphHash(path)).rejects.toThrow(
+      "Subgraph hash file is empty."
+    );
+  });
+
+  test("throws when contents are not a valid CID", async () => {
+    const path = await writeTempFile("invalid.txt", "not-a-cid");
+
+    await expect(loadSubgraphHash(path)).rejects.toThrow(
+      "Subgraph hash is not a valid IPFS hash"
+    );
+  });
+});

--- a/src/cli/commands/bootstrap/bootstrap.subgraph.ts
+++ b/src/cli/commands/bootstrap/bootstrap.subgraph.ts
@@ -1,0 +1,32 @@
+import { CID } from "multiformats/cid";
+
+const SUBGRAPH_HASH_KEY = "SUBGRAPH_HASH" as const;
+
+const loadSubgraphHash = async (path: string): Promise<string> => {
+  const trimmedPath = path.trim();
+  if (trimmedPath.length === 0) {
+    throw new Error("Subgraph hash file path must be provided.");
+  }
+
+  const file = Bun.file(trimmedPath);
+  if (!(await file.exists())) {
+    throw new Error(`Subgraph hash file not found at ${path}`);
+  }
+
+  const contents = (await file.text()).trim();
+  if (contents.length === 0) {
+    throw new Error("Subgraph hash file is empty.");
+  }
+
+  try {
+    CID.parse(contents);
+  } catch (error) {
+    throw new Error(
+      `Subgraph hash is not a valid IPFS hash: ${(error as Error).message}`
+    );
+  }
+
+  return contents;
+};
+
+export { loadSubgraphHash, SUBGRAPH_HASH_KEY };

--- a/src/constants/artifact-defaults.ts
+++ b/src/constants/artifact-defaults.ts
@@ -4,6 +4,7 @@ const ARTIFACT_DEFAULTS = {
   genesisConfigMapName: "besu-genesis",
   staticNodesConfigMapName: "besu-static-nodes",
   faucetArtifactPrefix: "besu-faucet",
+  subgraphConfigMapName: "besu-subgraph",
 } as const;
 
 export { ARTIFACT_DEFAULTS };


### PR DESCRIPTION
## Summary
- add a helper to load and validate the subgraph hash from a file
- include the subgraph hash ConfigMap in file and Kubernetes outputs with a default name
- wire the generate command to read the optional subgraph hash file and extend tests

## Testing
- bun test
- bun run typecheck
- bun run check

------
https://chatgpt.com/codex/tasks/task_e_68cf2d48dc44833287e31391dee5278e

## Summary by Sourcery

Add support for loading and publishing a subgraph IPFS hash as a ConfigMap in the network bootstrap process.

New Features:
- Introduce loadSubgraphHash helper to read and validate an IPFS hash from a file
- Add --subgraph-hash-file CLI option and SUBGRAPH_HASH_FILE environment variable to specify the subgraph hash file
- Include subgraph hash in payload and publish it as a ConfigMap in both file and Kubernetes outputs

Build:
- Add multiformats dependency for IPFS CID parsing

Documentation:
- Document the new --subgraph-hash-file option in the README

Tests:
- Add unit tests for loadSubgraphHash to validate file existence, emptiness, and CID format
- Extend bootstrap command and output tests to cover subgraph hash loading and ConfigMap generation